### PR TITLE
Http Clientを設定できるようにする

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/net/context"
-	"google.golang.org/appengine/urlfetch"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -285,7 +283,7 @@ type RPCRequests []*RPCRequest
 //
 // endpoint: JSON-RPC service URL to which JSON-RPC requests are sent.
 func NewClient(endpoint string) RPCClient {
-	return NewClientWithOpts(endpoint, nil, nil)
+	return NewClientWithOpts(endpoint, nil)
 }
 
 // NewClientWithOpts returns a new RPCClient instance with custom configuration.
@@ -293,7 +291,7 @@ func NewClient(endpoint string) RPCClient {
 // endpoint: JSON-RPC service URL to which JSON-RPC requests are sent.
 //
 // opts: RPCClientOpts provide custom configuration
-func NewClientWithOpts(endpoint string, opts *RPCClientOpts, c context.Context) RPCClient {
+func NewClientWithOpts(endpoint string, opts *RPCClientOpts) RPCClient {
 	rpcClient := &rpcClient{
 		endpoint:      endpoint,
 		httpClient:    &http.Client{},
@@ -312,10 +310,6 @@ func NewClientWithOpts(endpoint string, opts *RPCClientOpts, c context.Context) 
 		for k, v := range opts.CustomHeaders {
 			rpcClient.customHeaders[k] = v
 		}
-	}
-
-	if c != nil {
-		rpcClient.httpClient = urlfetch.Client(c)
 	}
 
 	return rpcClient

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/urlfetch"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -283,7 +285,7 @@ type RPCRequests []*RPCRequest
 //
 // endpoint: JSON-RPC service URL to which JSON-RPC requests are sent.
 func NewClient(endpoint string) RPCClient {
-	return NewClientWithOpts(endpoint, nil)
+	return NewClientWithOpts(endpoint, nil, nil)
 }
 
 // NewClientWithOpts returns a new RPCClient instance with custom configuration.
@@ -291,7 +293,7 @@ func NewClient(endpoint string) RPCClient {
 // endpoint: JSON-RPC service URL to which JSON-RPC requests are sent.
 //
 // opts: RPCClientOpts provide custom configuration
-func NewClientWithOpts(endpoint string, opts *RPCClientOpts) RPCClient {
+func NewClientWithOpts(endpoint string, opts *RPCClientOpts, c context.Context) RPCClient {
 	rpcClient := &rpcClient{
 		endpoint:      endpoint,
 		httpClient:    &http.Client{},
@@ -310,6 +312,10 @@ func NewClientWithOpts(endpoint string, opts *RPCClientOpts) RPCClient {
 		for k, v := range opts.CustomHeaders {
 			rpcClient.customHeaders[k] = v
 		}
+	}
+
+	if c != nil {
+		rpcClient.httpClient = urlfetch.Client(c)
 	}
 
 	return rpcClient

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -408,7 +408,6 @@ func (client *rpcClient) doCall(RPCRequest *RPCRequest) (*RPCResponse, error) {
 
 	var rpcResponse *RPCResponse
 	decoder := json.NewDecoder(httpResponse.Body)
-	decoder.DisallowUnknownFields()
 	decoder.UseNumber()
 	err = decoder.Decode(&rpcResponse)
 
@@ -452,7 +451,6 @@ func (client *rpcClient) doBatchCall(rpcRequest []*RPCRequest) ([]*RPCResponse, 
 
 	var rpcResponse RPCResponses
 	decoder := json.NewDecoder(httpResponse.Body)
-	decoder.DisallowUnknownFields()
 	decoder.UseNumber()
 	err = decoder.Decode(&rpcResponse)
 


### PR DESCRIPTION
# 対応するIssue
https://github.com/ventus-inc/BLOW_api/issues/128

# 理由
http clientにGAE上でコンテキストを渡す必要があるので、設定できるようにする必要がある

# やること

- [x] HttpClientwithOpsを拡張

# 動作確認
- [ ]
